### PR TITLE
Fix and enhance blocking stub generation

### DIFF
--- a/server-generator/src/test/golden/BlockingBidiStreamingService.kt
+++ b/server-generator/src/test/golden/BlockingBidiStreamingService.kt
@@ -14,6 +14,8 @@ import io.grpc.ServerServiceDefinition
 import io.grpc.ServiceDescriptor
 import io.grpc.ServiceDescriptor.newBuilder
 import io.grpc.stub.AbstractStub
+import io.grpc.stub.BlockingClientCall
+import io.grpc.stub.ClientCalls.blockingBidiStreamingCall
 import io.grpc.stub.StreamObserver
 import java.io.InputStream
 import java.lang.Class
@@ -162,5 +164,8 @@ public object TestServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): TestServiceBlockingStub =
         TestServiceBlockingStub(channel, callOptions)
+
+    public fun TestRPC(): BlockingClientCall<Test, Test> = blockingBidiStreamingCall(channel,
+        getTestRPCMethod(), callOptions)
   }
 }

--- a/server-generator/src/test/golden/BlockingClientStreamingService.kt
+++ b/server-generator/src/test/golden/BlockingClientStreamingService.kt
@@ -13,7 +13,8 @@ import io.grpc.ServerServiceDefinition
 import io.grpc.ServiceDescriptor
 import io.grpc.ServiceDescriptor.newBuilder
 import io.grpc.stub.AbstractStub
-import io.grpc.stub.ClientCalls.blockingServerStreamingCall
+import io.grpc.stub.BlockingClientCall
+import io.grpc.stub.ClientCalls.blockingClientStreamingCall
 import io.grpc.stub.StreamObserver
 import java.io.InputStream
 import java.lang.Class
@@ -21,7 +22,6 @@ import java.lang.UnsupportedOperationException
 import java.util.concurrent.ExecutorService
 import kotlin.Array
 import kotlin.String
-import kotlin.collections.Iterator
 import kotlin.collections.Map
 import kotlin.collections.Set
 import kotlin.jvm.Volatile
@@ -165,7 +165,7 @@ public object TestServiceWireGrpc {
     override fun build(channel: Channel, callOptions: CallOptions): TestServiceBlockingStub =
         TestServiceBlockingStub(channel, callOptions)
 
-    public fun TestRPC(request: Test): Iterator<Test> = blockingServerStreamingCall(channel,
-        getTestRPCMethod(), callOptions, request)
+    public fun TestRPC(): BlockingClientCall<Test, Test> = blockingClientStreamingCall(channel,
+        getTestRPCMethod(), callOptions)
   }
 }

--- a/server-generator/src/test/golden/BlockingServerStreamingService.kt
+++ b/server-generator/src/test/golden/BlockingServerStreamingService.kt
@@ -13,6 +13,9 @@ import io.grpc.ServerServiceDefinition
 import io.grpc.ServiceDescriptor
 import io.grpc.ServiceDescriptor.newBuilder
 import io.grpc.stub.AbstractStub
+import io.grpc.stub.BlockingClientCall
+import io.grpc.stub.ClientCalls.blockingServerStreamingCall
+import io.grpc.stub.ClientCalls.blockingV2ServerStreamingCall
 import io.grpc.stub.StreamObserver
 import java.io.InputStream
 import java.lang.Class
@@ -21,6 +24,7 @@ import java.util.concurrent.ExecutorService
 import kotlin.Array
 import kotlin.String
 import kotlin.Unit
+import kotlin.collections.Iterator
 import kotlin.collections.Map
 import kotlin.collections.Set
 import kotlin.jvm.Volatile
@@ -159,5 +163,11 @@ public object TestServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): TestServiceBlockingStub =
         TestServiceBlockingStub(channel, callOptions)
+
+    public fun TestRPC(request: Test): Iterator<Test> = blockingServerStreamingCall(channel,
+        getTestRPCMethod(), callOptions, request)
+
+    public fun TestRPCCall(request: Test): BlockingClientCall<Test, Test> =
+        blockingV2ServerStreamingCall(channel, getTestRPCMethod(), callOptions, request)
   }
 }

--- a/server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -14,8 +14,12 @@ import io.grpc.ServerServiceDefinition
 import io.grpc.ServiceDescriptor
 import io.grpc.ServiceDescriptor.newBuilder
 import io.grpc.stub.AbstractStub
+import io.grpc.stub.BlockingClientCall
+import io.grpc.stub.ClientCalls.blockingBidiStreamingCall
+import io.grpc.stub.ClientCalls.blockingClientStreamingCall
 import io.grpc.stub.ClientCalls.blockingServerStreamingCall
 import io.grpc.stub.ClientCalls.blockingUnaryCall
+import io.grpc.stub.ClientCalls.blockingV2ServerStreamingCall
 import io.grpc.stub.StreamObserver
 import java.io.InputStream
 import java.lang.Class
@@ -356,7 +360,16 @@ public object RouteGuideWireGrpc {
     public fun GetFeature(request: Point): Feature = blockingUnaryCall(channel,
         getGetFeatureMethod(), callOptions, request)
 
-    public fun RecordRoute(request: Point): Iterator<RouteSummary> =
-        blockingServerStreamingCall(channel, getRecordRouteMethod(), callOptions, request)
+    public fun ListFeatures(request: Rectangle): Iterator<Feature> =
+        blockingServerStreamingCall(channel, getListFeaturesMethod(), callOptions, request)
+
+    public fun ListFeaturesCall(request: Rectangle): BlockingClientCall<Rectangle, Feature> =
+        blockingV2ServerStreamingCall(channel, getListFeaturesMethod(), callOptions, request)
+
+    public fun RecordRoute(): BlockingClientCall<Point, RouteSummary> =
+        blockingClientStreamingCall(channel, getRecordRouteMethod(), callOptions)
+
+    public fun RouteChat(): BlockingClientCall<RouteNote, RouteNote> =
+        blockingBidiStreamingCall(channel, getRouteChatMethod(), callOptions)
   }
 }


### PR DESCRIPTION
The generation of blocking stubs was previously backwards. It was effectively creating -streaming code for client-streaming workflows, despite blocking client-streaming not being supported by gRPC at the time. This also made it impossible to use blocking  streaming, despite APIs for this being available. This has been fixed.

Additionally, experimental APIs were added via https://.com/grpc/grpc-java/issues/10918 in gRPC release 1.70.0 https://.com/grpc/grpc-java/releases/tag/v1.70.0 that enable calls that incorporate client streaming. Since 1.70.0 has been out for 6+ months, support for these APIs has been added. This change also brought a different API for  streaming, and support for that has been added as well.

All changes have been confirmed to generate compilable code that matches RPC expectations in a production project.