### PR TITLE
Add KDoc from proto comments to generated RPC methods.

### DIFF
--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BlockingStubGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BlockingStubGenerator.kt
@@ -54,6 +54,7 @@ object BlockingStubGenerator {
                 )
                 .addType(
                     TypeSpec.classBuilder(stubClassName)
+                        .addServiceKdoc(service)
                         .apply {
                             addAbstractStubConstructor(
                                 generator,

--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BlockingStubGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BlockingStubGenerator.kt
@@ -72,13 +72,14 @@ object BlockingStubGenerator {
     }
 
     private fun TypeSpec.Builder.addBlockingStubRpcCalls(generator: ClassNameGenerator, service: Service): TypeSpec.Builder {
+        val sourceFile = service.location.path
         service.rpcs
             .forEach { rpc ->
                 val functions = when {
-                    !rpc.requestStreaming && !rpc.responseStreaming -> unary(generator, rpc)
-                    rpc.requestStreaming && !rpc.responseStreaming -> clientStreaming(generator, rpc)
-                    !rpc.requestStreaming -> serverStreaming(generator, rpc)
-                    else -> bidi(generator, rpc)
+                    !rpc.requestStreaming && !rpc.responseStreaming -> unary(generator, rpc, sourceFile)
+                    rpc.requestStreaming && !rpc.responseStreaming -> clientStreaming(generator, rpc, sourceFile)
+                    !rpc.requestStreaming -> serverStreaming(generator, rpc, sourceFile)
+                    else -> bidi(generator, rpc, sourceFile)
                 }
 
                 functions.forEach(::addFunction)
@@ -86,7 +87,12 @@ object BlockingStubGenerator {
         return this
     }
 
-    private fun unary(generator: ClassNameGenerator, rpc: Rpc): List<FunSpec> {
+    /**
+     * Generates a blocking unary RPC method.
+     *
+     * @param sourceFile the proto file path, included in generated KDoc.
+     */
+    private fun unary(generator: ClassNameGenerator, rpc: Rpc, sourceFile: String): List<FunSpec> {
         val blockingUnaryCall = MemberName(enclosingClassName = clientCalls, simpleName = "blockingUnaryCall")
         val codeBlock = CodeBlock.of(
             "return %M(channel, get${rpc.name}Method(), callOptions, request)",
@@ -94,6 +100,7 @@ object BlockingStubGenerator {
         )
         return listOf(
             FunSpec.builder(rpc.name)
+                .apply { addRpcKdoc(rpc, sourceFile) }
                 .addParameter("request", ClassName.bestGuess(generator.classNameFor(rpc.requestType!!).toString()))
                 .returns(generator.classNameFor(rpc.responseType!!))
                 .addCode(codeBlock)
@@ -101,13 +108,19 @@ object BlockingStubGenerator {
         )
     }
 
-    private fun serverStreaming(generator: ClassNameGenerator, rpc: Rpc): List<FunSpec> {
+    /**
+     * Generates blocking server-streaming RPC methods.
+     *
+     * @param sourceFile the proto file path, included in generated KDoc.
+     */
+    private fun serverStreaming(generator: ClassNameGenerator, rpc: Rpc, sourceFile: String): List<FunSpec> {
         val blockingServerStreamingCall = MemberName(enclosingClassName = clientCalls, simpleName = "blockingServerStreamingCall")
         val codeBlock1 = CodeBlock.of(
             "return %M(channel, get${rpc.name}Method(), callOptions, request)",
             blockingServerStreamingCall,
         )
         val v1 = FunSpec.builder(rpc.name)
+            .apply { addRpcKdoc(rpc, sourceFile) }
             .addParameter("request", ClassName.bestGuess(generator.classNameFor(rpc.requestType!!).toString()))
             .returns(Iterator::class.asClassName().parameterizedBy(generator.classNameFor(rpc.responseType!!)))
             .addCode(codeBlock1)
@@ -122,6 +135,7 @@ object BlockingStubGenerator {
         // We have to give this method a different name to avoid conflicts.
         // Since this method returns a BlockingClientCall, suffix it with "Call".
         val v2 = FunSpec.builder("${rpc.name}Call")
+            .apply { addRpcKdoc(rpc, sourceFile) }
             .addParameter("request", ClassName.bestGuess(generator.classNameFor(rpc.requestType!!).toString()))
             .returns(
                 blockingClientCall.parameterizedBy(
@@ -135,7 +149,12 @@ object BlockingStubGenerator {
         return listOf(v1, v2)
     }
 
-    private fun clientStreaming(generator: ClassNameGenerator, rpc: Rpc): List<FunSpec> {
+    /**
+     * Generates a blocking client-streaming RPC method.
+     *
+     * @param sourceFile the proto file path, included in generated KDoc.
+     */
+    private fun clientStreaming(generator: ClassNameGenerator, rpc: Rpc, sourceFile: String): List<FunSpec> {
         val blockingClientStreamingCall = MemberName(enclosingClassName = clientCalls, simpleName = "blockingClientStreamingCall")
         val codeBlock = CodeBlock.of(
             "return %M(channel, get${rpc.name}Method(), callOptions)",
@@ -144,6 +163,7 @@ object BlockingStubGenerator {
 
         return listOf(
             FunSpec.builder(rpc.name)
+                .apply { addRpcKdoc(rpc, sourceFile) }
                 .returns(
                     blockingClientCall.parameterizedBy(
                         ClassName.bestGuess(generator.classNameFor(rpc.requestType!!).toString()),
@@ -155,7 +175,12 @@ object BlockingStubGenerator {
         )
     }
 
-    private fun bidi(generator: ClassNameGenerator, rpc: Rpc): List<FunSpec> {
+    /**
+     * Generates a blocking bidirectional-streaming RPC method.
+     *
+     * @param sourceFile the proto file path, included in generated KDoc.
+     */
+    private fun bidi(generator: ClassNameGenerator, rpc: Rpc, sourceFile: String): List<FunSpec> {
         val blockingBidiStreamingCall = MemberName(enclosingClassName = clientCalls, simpleName = "blockingBidiStreamingCall")
         val codeBlock = CodeBlock.of(
             "return %M(channel, get${rpc.name}Method(), callOptions)",
@@ -164,6 +189,7 @@ object BlockingStubGenerator {
 
         return listOf(
             FunSpec.builder(rpc.name)
+                .apply { addRpcKdoc(rpc, sourceFile) }
                 .returns(
                     blockingClientCall.parameterizedBy(
                         ClassName.bestGuess(generator.classNameFor(rpc.requestType!!).toString()),

--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
@@ -44,7 +44,7 @@ object ImplBaseGenerator {
         .addType(
             TypeSpec.classBuilder("${service.name}ImplBase")
                 .addModifiers(KModifier.ABSTRACT)
-                .addSuperinterface(ClassName("com.squareup.wire.kotlin.grpcserver","WireBindableService"))
+                .addSuperinterface(ClassName("com.squareup.wire.kotlin.grpcserver", "WireBindableService"))
                 .apply { addImplBaseConstructor(options) }
                 .apply { addImplBaseBody(generator, this, service, options) }
                 .build(),
@@ -125,6 +125,7 @@ object ImplBaseGenerator {
             builder.addFunction(
                 FunSpec.builder(rpc.name)
                     .addModifiers(KModifier.OPEN)
+                    .apply { addRpcKdoc(rpc, service.location.path) }
                     .apply { addImplBaseRpcSignature(generator, this, rpc, options) }
                     .apply { if (options.suspendingCalls && !rpc.responseStreaming) { addModifiers(KModifier.SUSPEND) } }
                     .addCode(CodeBlock.of("throw %T()", UnsupportedOperationException::class.java))
@@ -147,7 +148,7 @@ object ImplBaseGenerator {
                 val className = generator.classNameFor(it!!)
                 builder.addType(
                     TypeSpec.classBuilder("${it.simpleName}Marshaller")
-                        .addSuperinterface(ClassName("com.squareup.wire.kotlin.grpcserver","WireMethodMarshaller").parameterizedBy(className))
+                        .addSuperinterface(ClassName("com.squareup.wire.kotlin.grpcserver", "WireMethodMarshaller").parameterizedBy(className))
                         .addFunction(
                             FunSpec.builder("stream")
                                 .addModifiers(KModifier.OVERRIDE)

--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
@@ -44,6 +44,7 @@ object ImplBaseGenerator {
         .addType(
             TypeSpec.classBuilder("${service.name}ImplBase")
                 .addModifiers(KModifier.ABSTRACT)
+                .addServiceKdoc(service)
                 .addSuperinterface(ClassName("com.squareup.wire.kotlin.grpcserver", "WireBindableService"))
                 .apply { addImplBaseConstructor(options) }
                 .apply { addImplBaseBody(generator, this, service, options) }

--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGenerator.kt
@@ -43,6 +43,7 @@ class KotlinGrpcGenerator(
         val classNameGenerator = ClassNameGenerator(typeToKotlinName)
         val grpcClassName = classNameGenerator.classNameFor(service.type, "WireGrpc")
         val builder = TypeSpec.objectBuilder(grpcClassName)
+            .addServiceKdoc(service)
 
         addServiceDescriptor(builder, service, protoFile, schema)
         service.rpcs.forEach { rpc -> addMethodDescriptor(classNameGenerator, builder, service, rpc) }
@@ -56,6 +57,17 @@ class KotlinGrpcGenerator(
     companion object {
         data class Options(val singleMethodServices: Boolean, val suspendingCalls: Boolean)
     }
+}
+
+internal fun TypeSpec.Builder.addServiceKdoc(service: Service): TypeSpec.Builder {
+    val kdoc = buildString {
+        if (service.documentation.isNotBlank()) {
+            append(service.documentation)
+            append("\n\n")
+        }
+        append("Defined in ${service.location.path}")
+    }
+    return addKdoc("%L", kdoc)
 }
 
 internal fun FunSpec.Builder.addRpcKdoc(rpc: Rpc, sourceFile: String): FunSpec.Builder {

--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGenerator.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire.kotlin.grpcserver
 
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.wire.kotlin.grpcserver.BlockingStubGenerator.addBlockingStub
@@ -25,6 +26,7 @@ import com.squareup.wire.kotlin.grpcserver.ServiceDescriptorGenerator.addService
 import com.squareup.wire.kotlin.grpcserver.StubGenerator.addStub
 import com.squareup.wire.schema.ProtoFile
 import com.squareup.wire.schema.ProtoType
+import com.squareup.wire.schema.Rpc
 import com.squareup.wire.schema.Schema
 import com.squareup.wire.schema.Service
 
@@ -54,4 +56,15 @@ class KotlinGrpcGenerator(
     companion object {
         data class Options(val singleMethodServices: Boolean, val suspendingCalls: Boolean)
     }
+}
+
+internal fun FunSpec.Builder.addRpcKdoc(rpc: Rpc, sourceFile: String): FunSpec.Builder {
+    val kdoc = buildString {
+        if (rpc.documentation.isNotBlank()) {
+            append(rpc.documentation)
+            append("\n\n")
+        }
+        append("Defined in $sourceFile")
+    }
+    return addKdoc("%L", kdoc)
 }

--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/StubGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/StubGenerator.kt
@@ -62,6 +62,7 @@ object StubGenerator {
             )
             .addType(
                 TypeSpec.classBuilder(stubClassName)
+                    .addServiceKdoc(service)
                     .apply {
                         addAbstractStubConstructor(
                             generator,
@@ -98,6 +99,7 @@ object StubGenerator {
             )
             .addType(
                 TypeSpec.classBuilder(stubClassName)
+                    .addServiceKdoc(service)
                     .apply {
                         addAbstractStubConstructor(
                             generator,

--- a/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/StubGenerator.kt
+++ b/server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/StubGenerator.kt
@@ -176,6 +176,7 @@ object StubGenerator {
             }
             builder.addFunction(
                 FunSpec.builder(rpc.name)
+                    .apply { addRpcKdoc(rpc, service.location.path) }
                     .apply { addImplBaseRpcSignature(generator, this, rpc, options) }
                     .addCode(codeBlock)
                     .build(),
@@ -197,6 +198,7 @@ object StubGenerator {
             )
             builder.addFunction(
                 FunSpec.builder(rpc.name)
+                    .apply { addRpcKdoc(rpc, service.location.path) }
                     .apply { addImplBaseRpcSignature(generator, this, rpc, options) }
                     .addModifiers(KModifier.SUSPEND)
                     .addCode(codeBlock)

--- a/server-generator/src/test/golden/BlockingBidiStreamingService.kt
+++ b/server-generator/src/test/golden/BlockingBidiStreamingService.kt
@@ -107,6 +107,9 @@ public object TestServiceWireGrpc {
   public fun newBlockingStub(channel: Channel): TestServiceBlockingStub = TestServiceBlockingStub(channel)
 
   public abstract class TestServiceImplBase : WireBindableService {
+    /**
+     * Defined in service.proto
+     */
     public open fun TestRPC(response: StreamObserver<Test>): StreamObserver<Test> = throw UnsupportedOperationException()
 
     override fun bindService(): ServerServiceDefinition = ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
@@ -130,6 +133,9 @@ public object TestServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): TestServiceStub = TestServiceStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public fun TestRPC(response: StreamObserver<Test>): StreamObserver<Test> = clientCallsAsyncBidiStreamingCall(channel.newCall(getTestRPCMethod(), callOptions), response)
   }
 
@@ -140,6 +146,9 @@ public object TestServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): TestServiceBlockingStub = TestServiceBlockingStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public fun TestRPC(): BlockingClientCall<Test, Test> = blockingBidiStreamingCall(channel, getTestRPCMethod(), callOptions)
   }
 }

--- a/server-generator/src/test/golden/BlockingBidiStreamingService.kt
+++ b/server-generator/src/test/golden/BlockingBidiStreamingService.kt
@@ -26,6 +26,9 @@ import kotlin.jvm.Volatile
 import io.grpc.stub.ClientCalls.asyncBidiStreamingCall as clientCallsAsyncBidiStreamingCall
 import io.grpc.stub.ServerCalls.asyncBidiStreamingCall as serverCallsAsyncBidiStreamingCall
 
+/**
+ * Defined in service.proto
+ */
 public object TestServiceWireGrpc {
   public const val SERVICE_NAME: String = "test.TestService"
 
@@ -106,6 +109,9 @@ public object TestServiceWireGrpc {
 
   public fun newBlockingStub(channel: Channel): TestServiceBlockingStub = TestServiceBlockingStub(channel)
 
+  /**
+   * Defined in service.proto
+   */
   public abstract class TestServiceImplBase : WireBindableService {
     /**
      * Defined in service.proto
@@ -126,6 +132,9 @@ public object TestServiceWireGrpc {
     }
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class TestServiceStub : AbstractStub<TestServiceStub> {
     internal constructor(channel: Channel) : super(channel)
 
@@ -139,6 +148,9 @@ public object TestServiceWireGrpc {
     public fun TestRPC(response: StreamObserver<Test>): StreamObserver<Test> = clientCallsAsyncBidiStreamingCall(channel.newCall(getTestRPCMethod(), callOptions), response)
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class TestServiceBlockingStub : AbstractStub<TestServiceBlockingStub> {
     internal constructor(channel: Channel) : super(channel)
 

--- a/server-generator/src/test/golden/BlockingClientStreamingService.kt
+++ b/server-generator/src/test/golden/BlockingClientStreamingService.kt
@@ -107,6 +107,9 @@ public object TestServiceWireGrpc {
   public fun newBlockingStub(channel: Channel): TestServiceBlockingStub = TestServiceBlockingStub(channel)
 
   public abstract class TestServiceImplBase : WireBindableService {
+    /**
+     * Defined in service.proto
+     */
     public open fun TestRPC(response: StreamObserver<Test>): StreamObserver<Test> = throw UnsupportedOperationException()
 
     override fun bindService(): ServerServiceDefinition = ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
@@ -130,6 +133,9 @@ public object TestServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): TestServiceStub = TestServiceStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public fun TestRPC(response: StreamObserver<Test>): StreamObserver<Test> = clientCallsAsyncClientStreamingCall(channel.newCall(getTestRPCMethod(), callOptions), response)
   }
 
@@ -140,6 +146,9 @@ public object TestServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): TestServiceBlockingStub = TestServiceBlockingStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public fun TestRPC(): BlockingClientCall<Test, Test> = blockingClientStreamingCall(channel, getTestRPCMethod(), callOptions)
   }
 }

--- a/server-generator/src/test/golden/BlockingClientStreamingService.kt
+++ b/server-generator/src/test/golden/BlockingClientStreamingService.kt
@@ -26,6 +26,9 @@ import kotlin.jvm.Volatile
 import io.grpc.stub.ClientCalls.asyncClientStreamingCall as clientCallsAsyncClientStreamingCall
 import io.grpc.stub.ServerCalls.asyncClientStreamingCall as serverCallsAsyncClientStreamingCall
 
+/**
+ * Defined in service.proto
+ */
 public object TestServiceWireGrpc {
   public const val SERVICE_NAME: String = "test.TestService"
 
@@ -106,6 +109,9 @@ public object TestServiceWireGrpc {
 
   public fun newBlockingStub(channel: Channel): TestServiceBlockingStub = TestServiceBlockingStub(channel)
 
+  /**
+   * Defined in service.proto
+   */
   public abstract class TestServiceImplBase : WireBindableService {
     /**
      * Defined in service.proto
@@ -126,6 +132,9 @@ public object TestServiceWireGrpc {
     }
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class TestServiceStub : AbstractStub<TestServiceStub> {
     internal constructor(channel: Channel) : super(channel)
 
@@ -139,6 +148,9 @@ public object TestServiceWireGrpc {
     public fun TestRPC(response: StreamObserver<Test>): StreamObserver<Test> = clientCallsAsyncClientStreamingCall(channel.newCall(getTestRPCMethod(), callOptions), response)
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class TestServiceBlockingStub : AbstractStub<TestServiceBlockingStub> {
     internal constructor(channel: Channel) : super(channel)
 

--- a/server-generator/src/test/golden/BlockingServerStreamingService.kt
+++ b/server-generator/src/test/golden/BlockingServerStreamingService.kt
@@ -110,6 +110,9 @@ public object TestServiceWireGrpc {
   public fun newBlockingStub(channel: Channel): TestServiceBlockingStub = TestServiceBlockingStub(channel)
 
   public abstract class TestServiceImplBase : WireBindableService {
+    /**
+     * Defined in service.proto
+     */
     public open fun TestRPC(request: Test, response: StreamObserver<Test>): Unit = throw UnsupportedOperationException()
 
     override fun bindService(): ServerServiceDefinition = ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
@@ -133,6 +136,9 @@ public object TestServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): TestServiceStub = TestServiceStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public fun TestRPC(request: Test, response: StreamObserver<Test>) {
       clientCallsAsyncServerStreamingCall(channel.newCall(getTestRPCMethod(), callOptions), request, response)
     }
@@ -145,8 +151,14 @@ public object TestServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): TestServiceBlockingStub = TestServiceBlockingStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public fun TestRPC(request: Test): Iterator<Test> = blockingServerStreamingCall(channel, getTestRPCMethod(), callOptions, request)
 
+    /**
+     * Defined in service.proto
+     */
     public fun TestRPCCall(request: Test): BlockingClientCall<Test, Test> = blockingV2ServerStreamingCall(channel, getTestRPCMethod(), callOptions, request)
   }
 }

--- a/server-generator/src/test/golden/BlockingServerStreamingService.kt
+++ b/server-generator/src/test/golden/BlockingServerStreamingService.kt
@@ -29,6 +29,9 @@ import kotlin.jvm.Volatile
 import io.grpc.stub.ClientCalls.asyncServerStreamingCall as clientCallsAsyncServerStreamingCall
 import io.grpc.stub.ServerCalls.asyncServerStreamingCall as serverCallsAsyncServerStreamingCall
 
+/**
+ * Defined in service.proto
+ */
 public object TestServiceWireGrpc {
   public const val SERVICE_NAME: String = "test.TestService"
 
@@ -109,6 +112,9 @@ public object TestServiceWireGrpc {
 
   public fun newBlockingStub(channel: Channel): TestServiceBlockingStub = TestServiceBlockingStub(channel)
 
+  /**
+   * Defined in service.proto
+   */
   public abstract class TestServiceImplBase : WireBindableService {
     /**
      * Defined in service.proto
@@ -129,6 +135,9 @@ public object TestServiceWireGrpc {
     }
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class TestServiceStub : AbstractStub<TestServiceStub> {
     internal constructor(channel: Channel) : super(channel)
 
@@ -144,6 +153,9 @@ public object TestServiceWireGrpc {
     }
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class TestServiceBlockingStub : AbstractStub<TestServiceBlockingStub> {
     internal constructor(channel: Channel) : super(channel)
 

--- a/server-generator/src/test/golden/ImplBase.kt
+++ b/server-generator/src/test/golden/ImplBase.kt
@@ -15,6 +15,11 @@ import java.lang.UnsupportedOperationException
 import kotlin.Unit
 
 public class RouteGuideWireGrpc {
+  /**
+   * Interface exported by the server.
+   *
+   * Defined in src/test/proto/RouteGuideProto.proto
+   */
   public abstract class RouteGuideImplBase : WireBindableService {
     /**
      * A simple RPC.

--- a/server-generator/src/test/golden/ImplBase.kt
+++ b/server-generator/src/test/golden/ImplBase.kt
@@ -16,12 +16,48 @@ import kotlin.Unit
 
 public class RouteGuideWireGrpc {
   public abstract class RouteGuideImplBase : WireBindableService {
+    /**
+     * A simple RPC.
+     *
+     * Obtains the feature at a given position.
+     *
+     * A feature with an empty name is returned if there's no feature at the given
+     * position.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public open fun GetFeature(request: Point, response: StreamObserver<Feature>): Unit = throw UnsupportedOperationException()
 
+    /**
+     * A server-to-client streaming RPC.
+     *
+     * Obtains the Features available within the given Rectangle.  Results are
+     * streamed rather than returned at once (e.g. in a response message with a
+     * repeated field), as the rectangle may cover a large area and contain a
+     * huge number of features.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public open fun ListFeatures(request: Rectangle, response: StreamObserver<Feature>): Unit = throw UnsupportedOperationException()
 
+    /**
+     * A client-to-server streaming RPC.
+     *
+     * Accepts a stream of Points on a route being traversed, returning a
+     * RouteSummary when traversal is completed.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public open fun RecordRoute(response: StreamObserver<RouteSummary>): StreamObserver<Point> = throw UnsupportedOperationException()
 
+    /**
+     * A Bidirectional streaming RPC.
+     *
+     * Accepts a stream of RouteNotes sent while a route is being traversed,
+     * while receiving other RouteNotes (e.g. from other users).
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public open fun RouteChat(response: StreamObserver<RouteNote>): StreamObserver<RouteNote> = throw UnsupportedOperationException()
 
     override fun bindService(): ServerServiceDefinition = ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(

--- a/server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -38,6 +38,11 @@ import io.grpc.stub.ServerCalls.asyncClientStreamingCall as serverCallsAsyncClie
 import io.grpc.stub.ServerCalls.asyncServerStreamingCall as serverCallsAsyncServerStreamingCall
 import io.grpc.stub.ServerCalls.asyncUnaryCall as serverCallsAsyncUnaryCall
 
+/**
+ * Interface exported by the server.
+ *
+ * Defined in src/test/proto/RouteGuideProto.proto
+ */
 public object RouteGuideWireGrpc {
   public const val SERVICE_NAME: String = "routeguide.RouteGuide"
 
@@ -209,6 +214,11 @@ public object RouteGuideWireGrpc {
 
   public fun newBlockingStub(channel: Channel): RouteGuideBlockingStub = RouteGuideBlockingStub(channel)
 
+  /**
+   * Interface exported by the server.
+   *
+   * Defined in src/test/proto/RouteGuideProto.proto
+   */
   public abstract class RouteGuideImplBase : WireBindableService {
     /**
      * A simple RPC.
@@ -309,6 +319,11 @@ public object RouteGuideWireGrpc {
     }
   }
 
+  /**
+   * Interface exported by the server.
+   *
+   * Defined in src/test/proto/RouteGuideProto.proto
+   */
   public class RouteGuideStub : AbstractStub<RouteGuideStub> {
     internal constructor(channel: Channel) : super(channel)
 
@@ -365,6 +380,11 @@ public object RouteGuideWireGrpc {
     public fun RouteChat(response: StreamObserver<RouteNote>): StreamObserver<RouteNote> = clientCallsAsyncBidiStreamingCall(channel.newCall(getRouteChatMethod(), callOptions), response)
   }
 
+  /**
+   * Interface exported by the server.
+   *
+   * Defined in src/test/proto/RouteGuideProto.proto
+   */
   public class RouteGuideBlockingStub : AbstractStub<RouteGuideBlockingStub> {
     internal constructor(channel: Channel) : super(channel)
 

--- a/server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -210,12 +210,48 @@ public object RouteGuideWireGrpc {
   public fun newBlockingStub(channel: Channel): RouteGuideBlockingStub = RouteGuideBlockingStub(channel)
 
   public abstract class RouteGuideImplBase : WireBindableService {
+    /**
+     * A simple RPC.
+     *
+     * Obtains the feature at a given position.
+     *
+     * A feature with an empty name is returned if there's no feature at the given
+     * position.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public open fun GetFeature(request: Point, response: StreamObserver<Feature>): Unit = throw UnsupportedOperationException()
 
+    /**
+     * A server-to-client streaming RPC.
+     *
+     * Obtains the Features available within the given Rectangle.  Results are
+     * streamed rather than returned at once (e.g. in a response message with a
+     * repeated field), as the rectangle may cover a large area and contain a
+     * huge number of features.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public open fun ListFeatures(request: Rectangle, response: StreamObserver<Feature>): Unit = throw UnsupportedOperationException()
 
+    /**
+     * A client-to-server streaming RPC.
+     *
+     * Accepts a stream of Points on a route being traversed, returning a
+     * RouteSummary when traversal is completed.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public open fun RecordRoute(response: StreamObserver<RouteSummary>): StreamObserver<Point> = throw UnsupportedOperationException()
 
+    /**
+     * A Bidirectional streaming RPC.
+     *
+     * Accepts a stream of RouteNotes sent while a route is being traversed,
+     * while receiving other RouteNotes (e.g. from other users).
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public open fun RouteChat(response: StreamObserver<RouteNote>): StreamObserver<RouteNote> = throw UnsupportedOperationException()
 
     override fun bindService(): ServerServiceDefinition = ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
@@ -280,16 +316,52 @@ public object RouteGuideWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): RouteGuideStub = RouteGuideStub(channel, callOptions)
 
+    /**
+     * A simple RPC.
+     *
+     * Obtains the feature at a given position.
+     *
+     * A feature with an empty name is returned if there's no feature at the given
+     * position.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun GetFeature(request: Point, response: StreamObserver<Feature>) {
       clientCallsAsyncUnaryCall(channel.newCall(getGetFeatureMethod(), callOptions), request, response)
     }
 
+    /**
+     * A server-to-client streaming RPC.
+     *
+     * Obtains the Features available within the given Rectangle.  Results are
+     * streamed rather than returned at once (e.g. in a response message with a
+     * repeated field), as the rectangle may cover a large area and contain a
+     * huge number of features.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun ListFeatures(request: Rectangle, response: StreamObserver<Feature>) {
       clientCallsAsyncServerStreamingCall(channel.newCall(getListFeaturesMethod(), callOptions), request, response)
     }
 
+    /**
+     * A client-to-server streaming RPC.
+     *
+     * Accepts a stream of Points on a route being traversed, returning a
+     * RouteSummary when traversal is completed.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun RecordRoute(response: StreamObserver<RouteSummary>): StreamObserver<Point> = clientCallsAsyncClientStreamingCall(channel.newCall(getRecordRouteMethod(), callOptions), response)
 
+    /**
+     * A Bidirectional streaming RPC.
+     *
+     * Accepts a stream of RouteNotes sent while a route is being traversed,
+     * while receiving other RouteNotes (e.g. from other users).
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun RouteChat(response: StreamObserver<RouteNote>): StreamObserver<RouteNote> = clientCallsAsyncBidiStreamingCall(channel.newCall(getRouteChatMethod(), callOptions), response)
   }
 
@@ -300,14 +372,60 @@ public object RouteGuideWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): RouteGuideBlockingStub = RouteGuideBlockingStub(channel, callOptions)
 
+    /**
+     * A simple RPC.
+     *
+     * Obtains the feature at a given position.
+     *
+     * A feature with an empty name is returned if there's no feature at the given
+     * position.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun GetFeature(request: Point): Feature = blockingUnaryCall(channel, getGetFeatureMethod(), callOptions, request)
 
+    /**
+     * A server-to-client streaming RPC.
+     *
+     * Obtains the Features available within the given Rectangle.  Results are
+     * streamed rather than returned at once (e.g. in a response message with a
+     * repeated field), as the rectangle may cover a large area and contain a
+     * huge number of features.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun ListFeatures(request: Rectangle): Iterator<Feature> = blockingServerStreamingCall(channel, getListFeaturesMethod(), callOptions, request)
 
+    /**
+     * A server-to-client streaming RPC.
+     *
+     * Obtains the Features available within the given Rectangle.  Results are
+     * streamed rather than returned at once (e.g. in a response message with a
+     * repeated field), as the rectangle may cover a large area and contain a
+     * huge number of features.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun ListFeaturesCall(request: Rectangle): BlockingClientCall<Rectangle, Feature> = blockingV2ServerStreamingCall(channel, getListFeaturesMethod(), callOptions, request)
 
+    /**
+     * A client-to-server streaming RPC.
+     *
+     * Accepts a stream of Points on a route being traversed, returning a
+     * RouteSummary when traversal is completed.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun RecordRoute(): BlockingClientCall<Point, RouteSummary> = blockingClientStreamingCall(channel, getRecordRouteMethod(), callOptions)
 
+    /**
+     * A Bidirectional streaming RPC.
+     *
+     * Accepts a stream of RouteNotes sent while a route is being traversed,
+     * while receiving other RouteNotes (e.g. from other users).
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun RouteChat(): BlockingClientCall<RouteNote, RouteNote> = blockingBidiStreamingCall(channel, getRouteChatMethod(), callOptions)
   }
 }

--- a/server-generator/src/test/golden/Stub.kt
+++ b/server-generator/src/test/golden/Stub.kt
@@ -20,16 +20,52 @@ public class RouteGuideWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): RouteGuideStub = RouteGuideStub(channel, callOptions)
 
+    /**
+     * A simple RPC.
+     *
+     * Obtains the feature at a given position.
+     *
+     * A feature with an empty name is returned if there's no feature at the given
+     * position.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun GetFeature(request: Point, response: StreamObserver<Feature>) {
       asyncUnaryCall(channel.newCall(getGetFeatureMethod(), callOptions), request, response)
     }
 
+    /**
+     * A server-to-client streaming RPC.
+     *
+     * Obtains the Features available within the given Rectangle.  Results are
+     * streamed rather than returned at once (e.g. in a response message with a
+     * repeated field), as the rectangle may cover a large area and contain a
+     * huge number of features.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun ListFeatures(request: Rectangle, response: StreamObserver<Feature>) {
       asyncServerStreamingCall(channel.newCall(getListFeaturesMethod(), callOptions), request, response)
     }
 
+    /**
+     * A client-to-server streaming RPC.
+     *
+     * Accepts a stream of Points on a route being traversed, returning a
+     * RouteSummary when traversal is completed.
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun RecordRoute(response: StreamObserver<RouteSummary>): StreamObserver<Point> = asyncClientStreamingCall(channel.newCall(getRecordRouteMethod(), callOptions), response)
 
+    /**
+     * A Bidirectional streaming RPC.
+     *
+     * Accepts a stream of RouteNotes sent while a route is being traversed,
+     * while receiving other RouteNotes (e.g. from other users).
+     *
+     * Defined in src/test/proto/RouteGuideProto.proto
+     */
     public fun RouteChat(response: StreamObserver<RouteNote>): StreamObserver<RouteNote> = asyncBidiStreamingCall(channel.newCall(getRouteChatMethod(), callOptions), response)
   }
 }

--- a/server-generator/src/test/golden/Stub.kt
+++ b/server-generator/src/test/golden/Stub.kt
@@ -13,6 +13,11 @@ import io.grpc.stub.StreamObserver
 public class RouteGuideWireGrpc {
   public fun newStub(channel: Channel): RouteGuideStub = RouteGuideStub(channel)
 
+  /**
+   * Interface exported by the server.
+   *
+   * Defined in src/test/proto/RouteGuideProto.proto
+   */
   public class RouteGuideStub : AbstractStub<RouteGuideStub> {
     internal constructor(channel: Channel) : super(channel)
 

--- a/server-generator/src/test/golden/nonSingleMethodService.kt
+++ b/server-generator/src/test/golden/nonSingleMethodService.kt
@@ -135,8 +135,14 @@ public object FooServiceWireGrpc {
   public fun newBlockingStub(channel: Channel): FooServiceBlockingStub = FooServiceBlockingStub(channel)
 
   public abstract class FooServiceImplBase : WireBindableService {
+    /**
+     * Defined in service.proto
+     */
     public open fun Call1(request: Request, response: StreamObserver<Response>): Unit = throw UnsupportedOperationException()
 
+    /**
+     * Defined in service.proto
+     */
     public open fun Call2(request: Request, response: StreamObserver<Response>): Unit = throw UnsupportedOperationException()
 
     override fun bindService(): ServerServiceDefinition = ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
@@ -171,10 +177,16 @@ public object FooServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): FooServiceStub = FooServiceStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public fun Call1(request: Request, response: StreamObserver<Response>) {
       clientCallsAsyncUnaryCall(channel.newCall(getCall1Method(), callOptions), request, response)
     }
 
+    /**
+     * Defined in service.proto
+     */
     public fun Call2(request: Request, response: StreamObserver<Response>) {
       clientCallsAsyncUnaryCall(channel.newCall(getCall2Method(), callOptions), request, response)
     }
@@ -187,8 +199,14 @@ public object FooServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): FooServiceBlockingStub = FooServiceBlockingStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public fun Call1(request: Request): Response = blockingUnaryCall(channel, getCall1Method(), callOptions, request)
 
+    /**
+     * Defined in service.proto
+     */
     public fun Call2(request: Request): Response = blockingUnaryCall(channel, getCall2Method(), callOptions, request)
   }
 }

--- a/server-generator/src/test/golden/nonSingleMethodService.kt
+++ b/server-generator/src/test/golden/nonSingleMethodService.kt
@@ -26,6 +26,9 @@ import kotlin.jvm.Volatile
 import io.grpc.stub.ClientCalls.asyncUnaryCall as clientCallsAsyncUnaryCall
 import io.grpc.stub.ServerCalls.asyncUnaryCall as serverCallsAsyncUnaryCall
 
+/**
+ * Defined in service.proto
+ */
 public object FooServiceWireGrpc {
   public const val SERVICE_NAME: String = "foo.FooService"
 
@@ -134,6 +137,9 @@ public object FooServiceWireGrpc {
 
   public fun newBlockingStub(channel: Channel): FooServiceBlockingStub = FooServiceBlockingStub(channel)
 
+  /**
+   * Defined in service.proto
+   */
   public abstract class FooServiceImplBase : WireBindableService {
     /**
      * Defined in service.proto
@@ -170,6 +176,9 @@ public object FooServiceWireGrpc {
     }
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class FooServiceStub : AbstractStub<FooServiceStub> {
     internal constructor(channel: Channel) : super(channel)
 
@@ -192,6 +201,9 @@ public object FooServiceWireGrpc {
     }
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class FooServiceBlockingStub : AbstractStub<FooServiceBlockingStub> {
     internal constructor(channel: Channel) : super(channel)
 

--- a/server-generator/src/test/golden/singleMethodService.kt
+++ b/server-generator/src/test/golden/singleMethodService.kt
@@ -135,8 +135,14 @@ public object FooServiceWireGrpc {
   public fun newBlockingStub(channel: Channel): FooServiceBlockingStub = FooServiceBlockingStub(channel)
 
   public abstract class FooServiceImplBase : WireBindableService {
+    /**
+     * Defined in service.proto
+     */
     public open fun Call1(request: Request, response: StreamObserver<Response>): Unit = throw UnsupportedOperationException()
 
+    /**
+     * Defined in service.proto
+     */
     public open fun Call2(request: Request, response: StreamObserver<Response>): Unit = throw UnsupportedOperationException()
 
     override fun bindService(): ServerServiceDefinition = ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
@@ -171,10 +177,16 @@ public object FooServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): FooServiceStub = FooServiceStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public fun Call1(request: Request, response: StreamObserver<Response>) {
       clientCallsAsyncUnaryCall(channel.newCall(getCall1Method(), callOptions), request, response)
     }
 
+    /**
+     * Defined in service.proto
+     */
     public fun Call2(request: Request, response: StreamObserver<Response>) {
       clientCallsAsyncUnaryCall(channel.newCall(getCall2Method(), callOptions), request, response)
     }
@@ -187,8 +199,14 @@ public object FooServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): FooServiceBlockingStub = FooServiceBlockingStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public fun Call1(request: Request): Response = blockingUnaryCall(channel, getCall1Method(), callOptions, request)
 
+    /**
+     * Defined in service.proto
+     */
     public fun Call2(request: Request): Response = blockingUnaryCall(channel, getCall2Method(), callOptions, request)
   }
 }

--- a/server-generator/src/test/golden/singleMethodService.kt
+++ b/server-generator/src/test/golden/singleMethodService.kt
@@ -26,6 +26,9 @@ import kotlin.jvm.Volatile
 import io.grpc.stub.ClientCalls.asyncUnaryCall as clientCallsAsyncUnaryCall
 import io.grpc.stub.ServerCalls.asyncUnaryCall as serverCallsAsyncUnaryCall
 
+/**
+ * Defined in service.proto
+ */
 public object FooServiceWireGrpc {
   public const val SERVICE_NAME: String = "foo.FooService"
 
@@ -134,6 +137,9 @@ public object FooServiceWireGrpc {
 
   public fun newBlockingStub(channel: Channel): FooServiceBlockingStub = FooServiceBlockingStub(channel)
 
+  /**
+   * Defined in service.proto
+   */
   public abstract class FooServiceImplBase : WireBindableService {
     /**
      * Defined in service.proto
@@ -170,6 +176,9 @@ public object FooServiceWireGrpc {
     }
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class FooServiceStub : AbstractStub<FooServiceStub> {
     internal constructor(channel: Channel) : super(channel)
 
@@ -192,6 +201,9 @@ public object FooServiceWireGrpc {
     }
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class FooServiceBlockingStub : AbstractStub<FooServiceBlockingStub> {
     internal constructor(channel: Channel) : super(channel)
 

--- a/server-generator/src/test/golden/unitService.kt
+++ b/server-generator/src/test/golden/unitService.kt
@@ -22,6 +22,9 @@ import kotlin.collections.Set
 import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.Volatile
 
+/**
+ * Defined in service.proto
+ */
 public object MyServiceWireGrpc {
   public const val SERVICE_NAME: String = "MyService"
 
@@ -105,6 +108,9 @@ public object MyServiceWireGrpc {
 
   public fun newStub(channel: Channel): MyServiceStub = MyServiceStub(channel)
 
+  /**
+   * Defined in service.proto
+   */
   public abstract class MyServiceImplBase(
     protected val context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext
     ,
@@ -131,6 +137,9 @@ public object MyServiceWireGrpc {
     }
   }
 
+  /**
+   * Defined in service.proto
+   */
   public class MyServiceStub : AbstractCoroutineStub<MyServiceStub> {
     internal constructor(channel: Channel) : super(channel)
 

--- a/server-generator/src/test/golden/unitService.kt
+++ b/server-generator/src/test/golden/unitService.kt
@@ -109,6 +109,9 @@ public object MyServiceWireGrpc {
     protected val context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext
     ,
   ) : WireBindableService {
+    /**
+     * Defined in service.proto
+     */
     public open suspend fun doSomething(request: Unit): Unit = throw UnsupportedOperationException()
 
     override fun bindService(): ServerServiceDefinition = ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
@@ -135,6 +138,9 @@ public object MyServiceWireGrpc {
 
     override fun build(channel: Channel, callOptions: CallOptions): MyServiceStub = MyServiceStub(channel, callOptions)
 
+    /**
+     * Defined in service.proto
+     */
     public suspend fun doSomething(request: Unit): Unit = unaryRpc(channel, getdoSomethingMethod(), request, callOptions)
   }
 }

--- a/server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/StubTest.kt
+++ b/server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/StubTest.kt
@@ -88,6 +88,9 @@ class StubTest {
 
           override fun build(channel: Channel, callOptions: CallOptions): TestServiceStub = TestServiceStub(channel, callOptions)
 
+          /**
+           * Defined in test.proto
+           */
           public suspend fun TestRPC(request: Flow<Test>): Flow<Test> = bidiStreamingRpc(channel, getTestRPCMethod(), request, callOptions)
         }
       }
@@ -131,6 +134,9 @@ class StubTest {
 
           override fun build(channel: Channel, callOptions: CallOptions): TestServiceStub = TestServiceStub(channel, callOptions)
 
+          /**
+           * Defined in test.proto
+           */
           public suspend fun TestRPC(request: Test): Flow<Test> = serverStreamingRpc(channel, getTestRPCMethod(), request, callOptions)
         }
       }
@@ -174,6 +180,9 @@ class StubTest {
 
           override fun build(channel: Channel, callOptions: CallOptions): TestServiceStub = TestServiceStub(channel, callOptions)
 
+          /**
+           * Defined in test.proto
+           */
           public suspend fun TestRPC(request: Flow<Test>): Test = clientStreamingRpc(channel, getTestRPCMethod(), request, callOptions)
         }
       }

--- a/server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/StubTest.kt
+++ b/server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/StubTest.kt
@@ -81,6 +81,9 @@ class StubTest {
       public class TestServiceWireGrpc {
         public fun newStub(channel: Channel): TestServiceStub = TestServiceStub(channel)
 
+        /**
+         * Defined in test.proto
+         */
         public class TestServiceStub : AbstractCoroutineStub<TestServiceStub> {
           internal constructor(channel: Channel) : super(channel)
 
@@ -127,6 +130,9 @@ class StubTest {
       public class TestServiceWireGrpc {
         public fun newStub(channel: Channel): TestServiceStub = TestServiceStub(channel)
 
+        /**
+         * Defined in test.proto
+         */
         public class TestServiceStub : AbstractCoroutineStub<TestServiceStub> {
           internal constructor(channel: Channel) : super(channel)
 
@@ -173,6 +179,9 @@ class StubTest {
       public class TestServiceWireGrpc {
         public fun newStub(channel: Channel): TestServiceStub = TestServiceStub(channel)
 
+        /**
+         * Defined in test.proto
+         */
         public class TestServiceStub : AbstractCoroutineStub<TestServiceStub> {
           internal constructor(channel: Channel) : super(channel)
 


### PR DESCRIPTION
Proto RPC documentation and source file path are now included as KDoc on all generated method signatures across ImplBase, Stub, and BlockingStub.